### PR TITLE
Validator

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "schemats",
-  "version": "3.0.6",
+  "version": "3.0.7",
   "description": "Generate typescript interface definitions from (postgres) SQL database schema",
   "keywords": [
     "postgres",

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,7 +3,12 @@
  * Created by xiamx on 2016-08-10.
  */
 
-import { generateEnumType, generateTableTypes, generateTableInterface } from './typescript'
+import {
+    generateEnumType,
+    generateTableTypes,
+    generateTableInterface,
+    TableValidator
+} from './typescript'
 import { getDatabase, Database } from './schema'
 import Options, { OptionValues } from './options'
 import { processString, Options as ITFOptions } from 'typescript-formatter'
@@ -21,8 +26,18 @@ function getTime () {
     return `${yyyy}-${MM}-${dd} ${hh}:${mm}:${ss}`
 }
 
-function buildHeader (db: Database, tables: string[], schema: string|null, options: OptionValues): string {
-    let commands = ['schemats', 'generate', '-c', db.connectionString.replace(/:\/\/.*@/,'://username:password@')]
+function buildHeader (
+    db: Database,
+    tables: string[],
+    schema: string | null,
+    options: OptionValues
+): string {
+    let commands = [
+        'schemats',
+        'generate',
+        '-c',
+        db.connectionString.replace(/:\/\/.*@/, '://username:password@')
+    ]
     if (options.camelCase) commands.push('-C')
     if (tables.length > 0) {
         tables.forEach((t: string) => {
@@ -45,25 +60,43 @@ function buildHeader (db: Database, tables: string[], schema: string|null, optio
     `
 }
 
-export async function typescriptOfTable (db: Database|string, 
-                                         table: string,
-                                         schema: string,
-                                         options = new Options()) {
+export async function typescriptOfTable (
+    db: Database | string,
+    table: string,
+    schema: string,
+    options = new Options()
+): Promise<{ interfaces: string; validator: TableValidator }> {
     if (typeof db === 'string') {
         db = getDatabase(db)
     }
 
     let interfaces = ''
     let tableTypes = await db.getTableTypes(table, schema, options)
-    interfaces += generateTableTypes(table, tableTypes, options)
+    const { fields, validator } = generateTableTypes(
+        table,
+        tableTypes,
+        options
+    )
+    interfaces += fields
     interfaces += generateTableInterface(table, tableTypes, options)
-    return interfaces
+    return { interfaces, validator }
 }
 
-export async function typescriptOfSchema (db: Database|string,
-                                          tables: string[] = [],
-                                          schema: string|null = null,
-                                          options: OptionValues = {}): Promise<string> {
+export function validatorToString (validator: TableValidator) {
+    const lines: string[] = [`    ${validator.tableName}: {`]
+    for (const field of validator.fieldValidators) {
+        lines.push(`        ${field.fieldName}: ${field.validator},`)
+    }
+    lines.push('},')
+    return lines.join('\n')
+}
+
+export async function typescriptOfSchema (
+    db: Database | string,
+    tables: string[] = [],
+    schema: string | null = null,
+    options: OptionValues = {}
+): Promise<string> {
     if (typeof db === 'string') {
         db = getDatabase(db)
     }
@@ -78,10 +111,48 @@ export async function typescriptOfSchema (db: Database|string,
 
     const optionsObject = new Options(options)
 
-    const enumTypes = generateEnumType(await db.getEnumTypes(schema), optionsObject)
-    const interfacePromises = tables.map((table) => typescriptOfTable(db, table, schema as string, optionsObject))
-    const interfaces = await Promise.all(interfacePromises)
-        .then(tsOfTable => tsOfTable.join(''))
+    const enumTypes = generateEnumType(
+        await db.getEnumTypes(schema),
+        optionsObject
+    )
+    const tableResultPromises = tables.map((table) =>
+        typescriptOfTable(db, table, schema as string, optionsObject)
+    )
+    const tableResults = await Promise.all(tableResultPromises)
+    const interfaces = tableResults.map((r) => r.interfaces).join('')
+    const validators = tableResults.map((r) => r.validator)
+
+    const validatorStrings = [
+        `
+function validate(type: string, nullable: boolean) {
+    const validators = {
+        'boolean': (v: any) => typeof v == 'boolean',
+        'string': (v: any) => typeof v == 'string',
+        'number': (v: any) => typeof v == 'number',
+        'bigint': (v: any) => typeof v == 'bigint',
+        'Date': (v: any) => Object.prototype.toString.call(v) == '[object Date] && !isNaN(v)',
+        'Object': (v: any) => typeof v == 'object' && !!v,
+    }
+    if (!(type in validators)) {
+        throw new Error("Unsupported type: " + type)
+    }
+    return function (value: any) {
+        if (value === null) {
+            return nullable
+        }
+        const validate = validators[type as keyof typeof validators]
+        if (!validate) {
+            return false
+        }
+        return validate(value)
+    }
+}
+export const Validator = {`
+    ]
+    for (const validator of validators) {
+        validatorStrings.push(validatorToString(validator))
+    }
+    validatorStrings.push('}')
 
     let output = '/* tslint:disable */\n\n'
     if (optionsObject.options.writeHeader) {
@@ -89,6 +160,7 @@ export async function typescriptOfSchema (db: Database|string,
     }
     output += enumTypes
     output += interfaces
+    output += validatorStrings.join('\n')
 
     const formatterOption: ITFOptions = {
         replace: false,
@@ -104,9 +176,13 @@ export async function typescriptOfSchema (db: Database|string,
         tsfmtFile: null
     }
 
-    const processedResult = await processString('schema.ts', output, formatterOption)
+    const processedResult = await processString(
+        'schema.ts',
+        output,
+        formatterOption
+    )
     return processedResult.dest
 }
 
-export {Database, getDatabase} from './schema'
-export {Options, OptionValues}
+export { Database, getDatabase } from './schema'
+export { Options, OptionValues }

--- a/src/index.ts
+++ b/src/index.ts
@@ -130,7 +130,7 @@ function validate(type: string, nullable: boolean) {
         'string': (v: any) => typeof v == 'string',
         'number': (v: any) => typeof v == 'number',
         'bigint': (v: any) => typeof v == 'bigint',
-        'Date': (v: any) => Object.prototype.toString.call(v) == '[object Date] && !isNaN(v)',
+        'Date': (v: any) => Object.prototype.toString.call(v) == '[object Date]' && !isNaN(v),
         'Object': (v: any) => typeof v == 'object' && !!v,
     }
     if (!(type in validators)) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -136,7 +136,7 @@ function validate(type: string, nullable: boolean) {
     if (!(type in validators)) {
         throw new Error("Unsupported type: " + type)
     }
-    return function (value: any) {
+    const validateFn = (value: any) => {
         if (value === null) {
             return nullable
         }
@@ -146,6 +146,8 @@ function validate(type: string, nullable: boolean) {
         }
         return validate(value)
     }
+
+    return { validate: validateFn, nullable }
 }
 export const Validator = {`
     ]

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -29,4 +29,4 @@ export function getDatabase (connection: string): Database {
     }
 }
 
-export {Database} from './schemaInterfaces'
+export { Database } from './schemaInterfaces'

--- a/test/unit/typescript.test.ts
+++ b/test/unit/typescript.test.ts
@@ -7,122 +7,190 @@ const options = new Options({})
 describe('Typescript', () => {
     describe('generateTableInterface', () => {
         it('empty table definition object', () => {
-            const tableInterface = Typescript.generateTableInterface('tableName', {}, options)
-            assert.equal(tableInterface,
+            const tableInterface = Typescript.generateTableInterface(
+                'tableName',
+                {},
+                options
+            )
+            assert.equal(
+                tableInterface,
                 '\n' +
-                '        export interface tableName {\n' +
-                '        \n' +
-                '        }\n' +
-                '    ')
+                    '        export interface tableName {\n' +
+                    '        \n' +
+                    '        }\n' +
+                    '    '
+            )
         })
         it('table name is reserved', () => {
-            const tableInterface = Typescript.generateTableInterface('package', {}, options)
-            assert.equal(tableInterface,
+            const tableInterface = Typescript.generateTableInterface(
+                'package',
+                {},
+                options
+            )
+            assert.equal(
+                tableInterface,
                 '\n' +
-                '        export interface package_ {\n' +
-                '        \n' +
-                '        }\n' +
-                '    ')
+                    '        export interface package_ {\n' +
+                    '        \n' +
+                    '        }\n' +
+                    '    '
+            )
         })
         it('table with columns', () => {
-            const tableInterface = Typescript.generateTableInterface('tableName', {
-                col1: {udtName: 'name1', nullable: false},
-                col2: {udtName: 'name2', nullable: false}
-            }, options)
-            assert.equal(tableInterface,
+            const tableInterface = Typescript.generateTableInterface(
+                'tableName',
+                {
+                    col1: { udtName: 'name1', nullable: false },
+                    col2: { udtName: 'name2', nullable: false }
+                },
+                options
+            )
+            assert.equal(
+                tableInterface,
                 '\n' +
-                '        export interface tableName {\n' +
-                '        col1: tableNameFields.col1;\n' +
-                'col2: tableNameFields.col2;\n' +
-                '\n' +
-                '        }\n' +
-                '    ')
+                    '        export interface tableName {\n' +
+                    '        col1: tableNameFields.col1;\n' +
+                    'col2: tableNameFields.col2;\n' +
+                    '\n' +
+                    '        }\n' +
+                    '    '
+            )
         })
         it('table with reserved columns', () => {
-            const tableInterface = Typescript.generateTableInterface('tableName', {
-                string: {udtName: 'name1', nullable: false},
-                number: {udtName: 'name2', nullable: false},
-                package: {udtName: 'name3', nullable: false}
-            }, options)
-            assert.equal(tableInterface,
+            const tableInterface = Typescript.generateTableInterface(
+                'tableName',
+                {
+                    string: { udtName: 'name1', nullable: false },
+                    number: { udtName: 'name2', nullable: false },
+                    package: { udtName: 'name3', nullable: false }
+                },
+                options
+            )
+            assert.equal(
+                tableInterface,
                 '\n' +
-                '        export interface tableName {\n' +
-                '        string: tableNameFields.string_;\n' +
-                'number: tableNameFields.number_;\n' +
-                'package: tableNameFields.package_;\n' +
-                '\n' +
-                '        }\n' +
-                '    ')
+                    '        export interface tableName {\n' +
+                    '        string: tableNameFields.string_;\n' +
+                    'number: tableNameFields.number_;\n' +
+                    'package: tableNameFields.package_;\n' +
+                    '\n' +
+                    '        }\n' +
+                    '    '
+            )
         })
     })
     describe('generateEnumType', () => {
         it('empty object', () => {
             const enumType = Typescript.generateEnumType({}, options)
-            assert.equal(enumType,'')
+            assert.equal(enumType, '')
         })
         it('with enumerations', () => {
-            const enumType = Typescript.generateEnumType({
-                enum1: ['val1','val2','val3','val4'],
-                enum2: ['val5','val6','val7','val8']
-            }, options)
-            assert.equal(enumType,
-                'export type enum1 = \'val1\' | \'val2\' | \'val3\' | \'val4\';\n' +
-                'export type enum2 = \'val5\' | \'val6\' | \'val7\' | \'val8\';\n')
+            const enumType = Typescript.generateEnumType(
+                {
+                    enum1: ['val1', 'val2', 'val3', 'val4'],
+                    enum2: ['val5', 'val6', 'val7', 'val8']
+                },
+                options
+            )
+            assert.equal(
+                enumType,
+                "export type enum1 = 'val1' | 'val2' | 'val3' | 'val4';\n" +
+                    "export type enum2 = 'val5' | 'val6' | 'val7' | 'val8';\n"
+            )
         })
     })
     describe('generateEnumType', () => {
         it('empty object', () => {
             const enumType = Typescript.generateEnumType({}, options)
-            assert.equal(enumType,'')
+            assert.equal(enumType, '')
         })
         it('with enumerations', () => {
-            const enumType = Typescript.generateEnumType({
-                enum1: ['val1','val2','val3','val4'],
-                enum2: ['val5','val6','val7','val8']
-            }, options)
-            assert.equal(enumType,
-                'export type enum1 = \'val1\' | \'val2\' | \'val3\' | \'val4\';\n' +
-                'export type enum2 = \'val5\' | \'val6\' | \'val7\' | \'val8\';\n')
+            const enumType = Typescript.generateEnumType(
+                {
+                    enum1: ['val1', 'val2', 'val3', 'val4'],
+                    enum2: ['val5', 'val6', 'val7', 'val8']
+                },
+                options
+            )
+            assert.equal(
+                enumType,
+                "export type enum1 = 'val1' | 'val2' | 'val3' | 'val4';\n" +
+                    "export type enum2 = 'val5' | 'val6' | 'val7' | 'val8';\n"
+            )
         })
     })
     describe('generateTableTypes', () => {
         it('empty table definition object', () => {
-            const tableTypes = Typescript.generateTableTypes('tableName',{}, options)
-            assert.equal(tableTypes,
+            const { fields: tableTypes } = Typescript.generateTableTypes(
+                'tableName',
+                {},
+                options
+            )
+            assert.equal(
+                tableTypes,
                 '\n' +
-                '        export namespace tableNameFields {' +
-                '\n        ' +
-                '\n        ' +
-                '}' +
-                '\n    ')
+                    '        export namespace tableNameFields {' +
+                    '\n        ' +
+                    '\n        ' +
+                    '}' +
+                    '\n    '
+            )
         })
         it('with table definitions', () => {
-            const tableTypes = Typescript.generateTableTypes('tableName', {
-                col1: {udtName: 'name1', nullable: false, tsType: 'string'},
-                col2: {udtName: 'name2', nullable: false, tsType: 'number'}
-            }, options)
-            assert.equal(tableTypes,
+            const { fields: tableTypes } = Typescript.generateTableTypes(
+                'tableName',
+                {
+                    col1: {
+                        udtName: 'name1',
+                        nullable: false,
+                        tsType: 'string'
+                    },
+                    col2: {
+                        udtName: 'name2',
+                        nullable: false,
+                        tsType: 'number'
+                    }
+                },
+                options
+            )
+            assert.equal(
+                tableTypes,
                 '\n' +
-                '        export namespace tableNameFields {' +
-                '\n        export type col1 = string;' +
-                '\nexport type col2 = number;' +
-                '\n' +
-                '\n        }' +
-                '\n    ')
+                    '        export namespace tableNameFields {' +
+                    '\n        export type col1 = string;' +
+                    '\nexport type col2 = number;' +
+                    '\n' +
+                    '\n        }' +
+                    '\n    '
+            )
         })
         it('with nullable column definitions', () => {
-            const tableTypes = Typescript.generateTableTypes('tableName', {
-                col1: {udtName: 'name1', nullable: true, tsType: 'string'},
-                col2: {udtName: 'name2', nullable: true, tsType: 'number'}
-            }, options)
-            assert.equal(tableTypes,
+            const { fields: tableTypes } = Typescript.generateTableTypes(
+                'tableName',
+                {
+                    col1: {
+                        udtName: 'name1',
+                        nullable: true,
+                        tsType: 'string'
+                    },
+                    col2: {
+                        udtName: 'name2',
+                        nullable: true,
+                        tsType: 'number'
+                    }
+                },
+                options
+            )
+            assert.equal(
+                tableTypes,
                 '\n' +
-                '        export namespace tableNameFields {' +
-                '\n        export type col1 = string| null;' +
-                '\nexport type col2 = number| null;' +
-                '\n' +
-                '\n        }' +
-                '\n    ')
+                    '        export namespace tableNameFields {' +
+                    '\n        export type col1 = string| null;' +
+                    '\nexport type col2 = number| null;' +
+                    '\n' +
+                    '\n        }' +
+                    '\n    '
+            )
         })
     })
 })


### PR DESCRIPTION
Add a very simple validator for all tables/fields that can later be improved by using the actual column types.

```
function validate(type: string, nullable: boolean) {
    const validators = {
        'boolean': (v: any) => typeof v == 'boolean',
        'string': (v: any) => typeof v == 'string',
        'number': (v: any) => typeof v == 'number',
        'bigint': (v: any) => typeof v == 'bigint',
        'Date': (v: any) => Object.prototype.toString.call(v) == '[object Date] && !isNaN(v)',
        'Object': (v: any) => typeof v == 'object' && !!v,
    }
    if (!(type in validators)) {
        throw new Error("Unsupported type: " + type)
    }
    return function(value: any) {
        if (value === null) {
            return nullable
        }
        const validate = validators[type as keyof typeof validators]
        if (!validate) {
            return false
        }
        return validate(value)
    }
}
export const Validator = {
    affiliate: {
        id: validate('string', false),
        is_provider: validate('boolean', false),
        name: validate('string', false),
        coordinates: validate('string', true),
        address: validate('string', true),
        parent: validate('string', true),
        appliance_secret: validate('string', false),
        created_by: validate('string', true),
        created_at: validate('Date', false),
        updated_at: validate('Date', false),
    },
    affiliate_physical_port: {
        physical_port: validate('string', false),
        affiliate: validate('string', false),
        created_at: validate('Date', false),
    },
   ...
```