### PR TITLE
Upgrade pg-promise to 11.5.5 to fix CVE-2025-29744

### DIFF
--- a/dist/package.json
+++ b/dist/package.json
@@ -50,7 +50,7 @@
     },
     "dependencies": {
         "lodash": "^4.17.21",
-        "pg-promise": "^10.15.4",
+        "pg-promise": "^11.5.5",
         "typescript": "^4.9.5",
         "typescript-formatter": "^7.2.2",
         "yargs": "^16.2.0"

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
   },
   "dependencies": {
     "lodash": "^4.17.21",
-    "pg-promise": "^10.15.4",
+    "pg-promise": "^11.5.5",
     "typescript": "^4.9.5",
     "typescript-formatter": "^7.2.2",
     "yargs": "^16.2.0"


### PR DESCRIPTION
Fixes SQL injection vulnerability caused by improper handling of negative numbers in pg-promise versions prior to 11.5.5.

https://osv.dev/GHSA-ff9h-848c-4xfj