### PR TITLE
fix: replace deprecated prepublish with prepublishOnly and release 3.2.1

### DIFF
--- a/dist/package.json
+++ b/dist/package.json
@@ -16,7 +16,7 @@
         "test": "npm run test:unit",
         "test:unit": "jest --testMatch '<rootDir>/test/unit/**/*.test.ts'",
         "test:integration": "POSTGRES_URL=postgres://user:password@127.0.0.1:5432/test jest --testMatch '<rootDir>/test/integration/**/*.test.ts'",
-        "prepublish": "npm run build",
+        "prepublishOnly": "npm run build",
         "coverage": "npm run test:unit -- --coverage"
     },
     "bin": {

--- a/dist/package.json
+++ b/dist/package.json
@@ -1,6 +1,6 @@
 {
     "name": "schemats",
-    "version": "3.2.0",
+    "version": "3.2.1",
     "description": "Generate typescript interface definitions from (postgres) SQL database schema",
     "keywords": [
         "postgres",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "schemats",
-  "version": "3.2.0",
+  "version": "3.2.1",
   "description": "Generate typescript interface definitions from (postgres) SQL database schema",
   "keywords": [
     "postgres",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "test": "npm run test:unit",
     "test:unit": "jest --testMatch '<rootDir>/test/unit/**/*.test.ts'",
     "test:integration": "POSTGRES_URL=postgres://user:password@127.0.0.1:5432/test jest --testMatch '<rootDir>/test/integration/**/*.test.ts'",
-    "prepublish": "npm run build",
+    "prepublishOnly": "npm run build",
     "coverage": "npm run test:unit -- --coverage"
   },
   "bin": {


### PR DESCRIPTION
## Summary

- `prepublish` no longer runs on `npm publish` as of npm 7+, so replace it with `prepublishOnly`
- Bump version to 3.2.1 accordingly

Applies to both `package.json` and `dist/package.json`.