### PR TITLE
fix: rename build script to avoid triggering pacote git-dep preparation

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,6 +38,6 @@ jobs:
         node-version: ${{ matrix.node-version }}
     - run: npm install --prefer-offline
     - run: npm run lint
-    - run: npm run build -- --noEmit
+    - run: npm run compile -- --noEmit
     - run: npm run test
     - run: npm run test:integration

--- a/dist/package.json
+++ b/dist/package.json
@@ -1,6 +1,6 @@
 {
     "name": "schemats",
-    "version": "3.2.1",
+    "version": "3.2.2",
     "description": "Generate typescript interface definitions from (postgres) SQL database schema",
     "keywords": [
         "postgres",

--- a/dist/package.json
+++ b/dist/package.json
@@ -12,11 +12,11 @@
     "types": "./dist/src/index.d.ts",
     "scripts": {
         "lint": "eslint .",
-        "build": "tsc",
+        "compile": "tsc",
         "test": "npm run test:unit",
         "test:unit": "jest --testMatch '<rootDir>/test/unit/**/*.test.ts'",
         "test:integration": "POSTGRES_URL=postgres://user:password@127.0.0.1:5432/test jest --testMatch '<rootDir>/test/integration/**/*.test.ts'",
-        "prepublishOnly": "npm run build",
+        "prepublishOnly": "npm run compile",
         "coverage": "npm run test:unit -- --coverage"
     },
     "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "schemats",
-  "version": "3.2.1",
+  "version": "3.2.2",
   "description": "Generate typescript interface definitions from (postgres) SQL database schema",
   "keywords": [
     "postgres",

--- a/package.json
+++ b/package.json
@@ -12,11 +12,11 @@
   "types": "./dist/src/index.d.ts",
   "scripts": {
     "lint": "eslint .",
-    "build": "tsc",
+    "compile": "tsc",
     "test": "npm run test:unit",
     "test:unit": "jest --testMatch '<rootDir>/test/unit/**/*.test.ts'",
     "test:integration": "POSTGRES_URL=postgres://user:password@127.0.0.1:5432/test jest --testMatch '<rootDir>/test/integration/**/*.test.ts'",
-    "prepublishOnly": "npm run build",
+    "prepublishOnly": "npm run compile",
     "coverage": "npm run test:unit -- --coverage"
   },
   "bin": {


### PR DESCRIPTION
## Summary

- npm's pacote unconditionally runs a nested `npm install` of this package's own devDependencies whenever it is installed via a `github:`/git spec and `package.json` defines a `build` script (or any of `postinstall`/`preinstall`/`install`/`prepack`/`prepare`), even when the outer install passes `--ignore-scripts`
- This caused `npm ci --ignore-scripts` to fail downstream with `git dep preparation failed` whenever schemats' own devDependency resolution had trouble (e.g. an unresolvable `@typescript-eslint/eslint-plugin` version), unrelated to the consuming project
- Rename `build` to `compile` in `package.json` and `dist/package.json` (and update `prepublishOnly`/CI accordingly) so pacote no longer detects a trigger script and skips this unnecessary preparation step entirely; `dist/` is already committed so no build is needed for consumers anyway

This is a known, long-standing npm behavior: https://github.com/npm/cli/issues/2784